### PR TITLE
Fixes a type error for cases where an AN field is made up of all numbers

### DIFF
--- a/lib/iso8583/codec.rb
+++ b/lib/iso8583/codec.rb
@@ -119,14 +119,16 @@ module ISO8583
   A_Codec.decoder = PASS_THROUGH_DECODER
 
   AN_Codec = Codec.new
-  AN_Codec.encoder = lambda{|str|
+  AN_Codec.encoder = lambda{|val|
+    str = val.to_s
     raise ISO8583Exception.new("Invalid value: #{str} must be [A-Za-y0-9]") unless str =~ /^[A-Za-z0-9]*$/
     str
   }
   AN_Codec.decoder = PASS_THROUGH_DECODER
 
   ANP_Codec = Codec.new
-  ANP_Codec.encoder = lambda{|str|
+  ANP_Codec.encoder = lambda{|val|
+    str = val.to_s
     raise ISO8583Exception.new("Invalid value: #{str} must be [A-Za-y0-9 ]") unless str =~ /^[A-Za-z0-9 ]*$/
     str
   }


### PR DESCRIPTION
Hi,

I _think_ I've found a very small bug in the way that alpha-numeric fields are parsed.

In the case where the an AN field is entirely numeric it can be passed in as type Fixnum.  Under ruby 1.9 this won't be cast to string when =~ is called, we end up with an exception being thrown.

I've added a couple of explicit to_s calls to fix this this.

Cheers,
Sean.
