### PR TITLE
Can now remove fields in message

### DIFF
--- a/lib/iso8583/message.rb
+++ b/lib/iso8583/message.rb
@@ -147,9 +147,13 @@ module ISO8583
     #    mes[2]=47474747                          # bmp 2 is generally the PAN
     #    mes["Primary Account Number"]=47474747   # if thats what you called the field in Message.bmp.
     def []=(key, value)
-      bmp_def              = _get_definition key
-      bmp_def.value        = value
-      @values[bmp_def.bmp] = bmp_def 
+      if value.nil?
+        @values.delete(key)
+      else
+        bmp_def              = _get_definition key
+        bmp_def.value        = value
+        @values[bmp_def.bmp] = bmp_def
+      end
     end
 
     # Retrieve the decoded value of the contents of a bitmap

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -160,4 +160,14 @@ END
     mes2 = BerlinMessage.parse(mes.to_b)
     assert_equal(mes.to_b, mes2.to_b)
   end
+
+  def test_remove_field
+    mes     = BerlinMessage.new
+    mes.mti = "Network Management Request Response Issuer Gateway or Acquirer Gateway"
+    mes[3]  = nil
+
+    assert_nothing_raised do
+      mes.to_b
+    end
+  end
 end


### PR DESCRIPTION
This enables removal of fields. Otherwise the field would have a value of `nil`, which for some types (e.g. `Integer`) raises an exception when encoding the message.
