### PR TITLE
Use StandardError as base eception class

### DIFF
--- a/lib/iso8583/exception.rb
+++ b/lib/iso8583/exception.rb
@@ -1,4 +1,4 @@
 module ISO8583
-  class ISO8583Exception < Exception; end
+  class ISO8583Exception < StandardError; end
   class ISO8583ParseException < ISO8583Exception; end
 end

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -45,6 +45,17 @@ class MessageTest < Test::Unit::TestCase
     assert_equal 1430, mes.mti
   end
 
+  def test_rescue_standard_error
+    rescued = false
+    begin
+      BerlinMessage.parse("bogus")
+    rescue => error
+      rescued = true
+    end
+
+    assert rescued
+  end
+
   def test_to_s
     mes     = BerlinMessage.new
     mes.mti = "Network Management Request Response Issuer Gateway or Acquirer Gateway" 


### PR DESCRIPTION
When using a `rescue` without specifying the class to rescue, only StandardError is rescued. As I understand it, errors other than `StamdardError` are kind of reserved for fatal problems like memory errors.

This changes the base ISO8583Excpetion to be a StandardError.