### PR TITLE
Don't yield on each for the first bit in a bitmap.

### DIFF
--- a/lib/iso8583/bitmap.rb
+++ b/lib/iso8583/bitmap.rb
@@ -23,10 +23,11 @@ module ISO8583
     end
     
     # yield once with the number of each set field.
-    def each #:yields: each bit set in the bitmap.
-      @bmp.each_with_index {|set, i| yield i+1 if set}
+    # :yields: each bit set in the bitmap. Except for the first bit which is used to determine the bitmap sizec
+    def each
+      @bmp.each_with_index {|set, i| yield i+1 if set && i != 0}
     end
-    
+
     # Returns whether the bit is set or not.
     def [](i)
       @bmp[i-1]


### PR DESCRIPTION
Because the first bit is used to determine the length of the bitmap not to access a field, this code would crash if the first bit was set, because we'd attempt to access a field for bit 1 which wouldn't exist.