### PR TITLE
has_rdoc= is deprecated with no replacement

### DIFF
--- a/iso8583.gemspec
+++ b/iso8583.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.required_ruby_version     = ">= 1.9"
   s.rubyforge_project         = "iso8583"
-  s.has_rdoc                  = true
   
   s.requirements << "none"
   


### PR DESCRIPTION
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from [..]/8583/iso8583.gemspec:20.