### PR TITLE
Signal missing field info when a BMP definition can't be found.

### DIFF
--- a/lib/iso8583/message.rb
+++ b/lib/iso8583/message.rb
@@ -343,15 +343,19 @@ module ISO8583
           # @values[bmp] = bmp_def
         }
       end
-      
+
       # Parse the bytes `str` returning a message of the defined type.
+      #
+      # returns an instance of Message
+      #
+      # will raise an ISO8583Exception if the bitmap definition can't be found
       def parse(str)
         str = str.force_encoding('ASCII-8BIT')
         message = self.new
         message.mti, rest = _mti_format.parse(str)
         bmp,rest = Bitmap.parse(rest)
         bmp.each {|bit|
-          bmp_def      = _definitions[bit]
+          bmp_def      = message._get_definition(bit)
           value, rest  = bmp_def.field.parse(rest)
           message[bit] = value
         }

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -45,6 +45,12 @@ class MessageTest < Test::Unit::TestCase
     assert_equal 1430, mes.mti
   end
 
+  def test_unknown_field
+    assert_raises(ISO8583Exception.new("no definition for field: 8")) {
+      mes = BerlinMessage.parse "1430A\000\000\000\000\000\000\00012474747474747"
+    }
+  end
+
   def test_rescue_standard_error
     rescued = false
     begin


### PR DESCRIPTION
Current behaviour is to raise a `NoMethodError: undefined method 'field' for nil:NilClass`.
By delegating the definition finding to the message instance, we can rely on the check implemented in `Message#_get_definitions` and have a proper `ISO8583Exception` raised, which carries the info of the missing field so it can be debugged.